### PR TITLE
Minor fixes for Mac OS X

### DIFF
--- a/nana/CMakeLists.txt
+++ b/nana/CMakeLists.txt
@@ -126,7 +126,9 @@ endif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 # enable static linkage     # GNU || CLang not MinGW
 if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") #  AND NOT MINGW
     # set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++  -pthread")
-    set(NANA_LINKS "${NANA_LINKS} -static-libgcc -static-libstdc++  -pthread")
+    if (NOT APPLE)
+      set(NANA_LINKS "${NANA_LINKS} -static-libgcc -static-libstdc++  -pthread")
+    endif (NOT APPLE)
     # message("Setting NANA_LINKS to -static-libgcc -static-libstdc++  -pthread or ${NANA_LINKS}")
     if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.3)
 	                                                                     # IS_GNUCXX < 5.3
@@ -136,13 +138,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") #  AN
     endif(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.3)
     
 endif(CMAKE_COMPILER_IS_GNUCXX OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang") #  AND NOT MINGW
-
-
-if (APPLE AND "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")                    # APPLE Clang
-  # set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libstdc++")
-  set(NANA_LINKS "${NANA_LINKS} -stdlib=libstdc++")
-endif ()
-
 
 ############# Optional libraries
 

--- a/nana/CMakeLists.txt
+++ b/nana/CMakeLists.txt
@@ -248,7 +248,7 @@ endforeach(subdir ${NANA_SOURCE_SUBDIRS})
 
 include_directories(${NANA_INCLUDE_DIR})
 add_library(${PROJECT_NAME} ${sources} )
-target_link_libraries(${PROJECT_NAME} ${NANA_LINKS}) 
+target_link_libraries(${PROJECT_NAME} ${NANA_LINKS} iconv)
 
  #  Headers: use INCLUDE_DIRECTORIES
  #  Libraries: use FIND_LIBRARY and link with the result of it (try to avoid LINK_DIRECTORIES)

--- a/nana/include/nana/c++defines.hpp
+++ b/nana/include/nana/c++defines.hpp
@@ -61,7 +61,7 @@
 #	else
 #		undef STD_FILESYSTEM_NOT_SUPPORTED
 #	endif
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && !defined(__clang__)
 #	if (__GNUC__ == 4 && __GNUC_MINOR__ < 6)
 #		define noexcept		//no support of noexcept until GCC 4.6
 #	endif

--- a/nana/source/charset.cpp
+++ b/nana/source/charset.cpp
@@ -21,6 +21,7 @@
 #include <clocale>
 #include <cstring>	//Added by Pr0curo(pr#98)
 #include <memory>
+#include <locale>
 
 //GCC 4.7.0 does not implement the <codecvt> and codecvt_utfx classes
 #ifndef STD_CODECVT_NOT_SUPPORTED

--- a/nana/source/detail/platform_spec_posix.cpp
+++ b/nana/source/detail/platform_spec_posix.cpp
@@ -21,6 +21,7 @@
 
 #include <X11/Xlocale.h>
 #include <locale>
+#include <clocale>
 #include <map>
 #include <set>
 #include <algorithm>


### PR DESCRIPTION
Hi Felix,

thank you for sharing the material. I've got it compiled on Mac with native clang, and a ToT clang build. Users may want to change library search path to find correct libiconv. I use MacPorts, not homebrew, and mine is in /opt/local/lib. After fixing the library search path, it links and works (shows a window).